### PR TITLE
Make it compilable even without U#

### DIFF
--- a/Packages/red.sim.lightvolumes/UScripts/LightVolumeInstance.cs
+++ b/Packages/red.sim.lightvolumes/UScripts/LightVolumeInstance.cs
@@ -1,12 +1,16 @@
-﻿
+﻿using UnityEngine;
+#if UDONSHARP
 using UdonSharp;
-using UnityEngine;
-using VRC.SDKBase;
-using VRC.Udon;
+#endif
 
 namespace VRCLightVolumes {
+#if UDONSHARP
     [UdonBehaviourSyncMode(BehaviourSyncMode.None)]
-    public class LightVolumeInstance : UdonSharpBehaviour {
+    public class LightVolumeInstance : UdonSharpBehaviour
+#else
+    public class LightVolumeInstance : MonoBehaviour
+#endif
+    {
 
         [Tooltip("Changing the color is useful for animating Additive volumes. You can even control the R, G, B channels separately this way.")]
         [ColorUsage(showAlpha: false, hdr: true)]

--- a/Packages/red.sim.lightvolumes/UScripts/LightVolumeManager.cs
+++ b/Packages/red.sim.lightvolumes/UScripts/LightVolumeManager.cs
@@ -71,9 +71,9 @@ namespace VRCLightVolumes {
 
             VRCShader.SetGlobalVectorArray(lightVolumeInvLocalEdgeSmoothID, new Vector4[32]);
             VRCShader.SetGlobalMatrixArray(lightVolumeInvWorldMatrixID, new Matrix4x4[32]);
-            VRCShader.SetGlobalVectorArray(lightVolumeUvwID, new Vector4[64]);
-            VRCShader.SetGlobalVectorArray(lightVolumeColorID, new Vector4[192]);
-            VRCShader.SetGlobalVectorArray(lightVolumeRotationID, new Vector4[32]);
+            VRCShader.SetGlobalVectorArray(lightVolumeRotationID, new Vector4[64]);
+            VRCShader.SetGlobalVectorArray(lightVolumeUvwID, new Vector4[192]);
+            VRCShader.SetGlobalVectorArray(lightVolumeColorID, new Vector4[32]);
             _isInitialized = true;
         }
 


### PR DESCRIPTION
I found out this package cannot be used without U# (I would like to test it in avatar projects), so I modified it a bit.
Also, I have tweaked the usage of `VRCShader.PropertyToID`, cache it on initialize and reuse that ID number in the rest.