### PR TITLE
Prevent redundant (intermediate) volume data bundle with the world build

### DIFF
--- a/Packages/red.sim.lightvolumes/Scripts/Editor/LightVolumeBuildPreprocessor.cs
+++ b/Packages/red.sim.lightvolumes/Scripts/Editor/LightVolumeBuildPreprocessor.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using UnityEditor;
+using UnityEditor.Callbacks;
+
+namespace VRCLightVolumes {
+    internal static class LightVolumePreprocessor {
+        [PostProcessScene]
+        static void OnPostProcessScene() {
+            if (!BuildPipeline.isBuildingPlayer) return; // We only want to cleanup on build
+            var roots = SceneManager.GetActiveScene().GetRootGameObjects();
+            Cleanup<LightVolume>(roots);
+            Cleanup<LightVolumeSetup>(roots);
+        }
+
+        static void Cleanup<T>(GameObject[] roots) where T : Component {
+            var temp = new List<T>();
+            foreach (var go in roots) {
+                if (go == null) continue;
+                go.GetComponentsInChildren(true, temp);
+                foreach (var component in temp) {
+                    if (component == null) continue;
+                    Object.DestroyImmediate(component);
+                }
+            }
+        }
+    }
+}

--- a/Packages/red.sim.lightvolumes/Scripts/Editor/LightVolumeBuildPreprocessor.cs.meta
+++ b/Packages/red.sim.lightvolumes/Scripts/Editor/LightVolumeBuildPreprocessor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d9c4cef5d9ffe5544814976dbd92b7ab
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/red.sim.lightvolumes/Scripts/LightVolume.cs
+++ b/Packages/red.sim.lightvolumes/Scripts/LightVolume.cs
@@ -16,7 +16,7 @@ namespace VRCLightVolumes {
         public bool Dynamic;
         [Tooltip("Additive volumes apply their light on top of others as an overlay. Useful for movable lights like flashlights, projectors, disco balls, etc. They can also project light onto static lightmapped objects if the surface shader supports it.")]
         public bool Additive;
-        [Tooltip("Multiplies the volume’s color by this value.")]
+        [Tooltip("Multiplies the volumeâ€™s color by this value.")]
         [ColorUsage(showAlpha: false, hdr: true)]
         public Color Color = Color.white;
         [Tooltip("Size in meters of this Light Volume's overlapping regions for smooth blending with other volumes.")]
@@ -275,6 +275,7 @@ namespace VRCLightVolumes {
         // Create or destroy Bakery Volume
         if (LightVolumeSetup.IsBakeryMode && Bake && BakeryVolume == null) {
             GameObject obj = new GameObject($"Bakery Volume - {gameObject.name}");
+            obj.tag = "EditorOnly";
             obj.transform.parent = transform;
             BakeryVolume = obj.AddComponent<BakeryVolume>();
         } else if ((!LightVolumeSetup.IsBakeryMode || !Bake) && BakeryVolume != null) {
@@ -289,6 +290,7 @@ namespace VRCLightVolumes {
         if (LightVolumeSetup.IsBakeryMode && BakeryVolume != null) {
             // Sync bakery volume with light volume
             BakeryVolume.gameObject.name = $"Bakery Volume - {gameObject.name}";
+            BakeryVolume.gameObject.tag = "EditorOnly";
             if (BakeryVolume.transform.parent != transform) BakeryVolume.transform.parent = transform;
             BakeryVolume.transform.SetLocalPositionAndRotation(Vector3.zero, Quaternion.identity);
             BakeryVolume.transform.localScale = Vector3.one;


### PR DESCRIPTION
I have found some intermediate volume data was bundled to the world, which isn't directly used (see the highlighted entries on this screenshot)
![before](https://github.com/user-attachments/assets/71684e30-1d3b-45ce-b9bb-eaf670509140)

After investigation, the cause on inclusion of these texture3d is because your helper components with those references was serialized.
Therefore, I have patched it to remove those helper components on build, also add "EditorOnly" tag to the generated Bakery volume object.

After patching it, we can save a couple of MBs of bandwidth when loading the world:
![after](https://github.com/user-attachments/assets/253a9e56-b048-4f03-9f87-eb9dcb36eacf)

