### PR TITLE
Add include guard to LightVolumes.cginc

### DIFF
--- a/Packages/red.sim.lightvolumes/Shaders/LightVolumes.cginc
+++ b/Packages/red.sim.lightvolumes/Shaders/LightVolumes.cginc
@@ -1,5 +1,5 @@
-#ifndef LIGHT_VOLUMES_INCLUDED
-#define LIGHT_VOLUMES_INCLUDED
+#ifndef VRC_LIGHT_VOLUMES_INCLUDED
+#define VRC_LIGHT_VOLUMES_INCLUDED
 
 // Are Light Volumes enabled on scene?
 uniform float _UdonLightVolumeEnabled;

--- a/Packages/red.sim.lightvolumes/Shaders/LightVolumes.cginc
+++ b/Packages/red.sim.lightvolumes/Shaders/LightVolumes.cginc
@@ -1,3 +1,5 @@
+#ifndef LIGHT_VOLUMES_INCLUDED
+#define LIGHT_VOLUMES_INCLUDED
 
 // Are Light Volumes enabled on scene?
 uniform float _UdonLightVolumeEnabled;
@@ -338,3 +340,5 @@ void LightVolumeAdditiveSH(float3 worldPos, out float3 L0, out float3 L1r, out f
     }
 
 }
+
+#endif


### PR DESCRIPTION
Prevents re-definitions if included multiple times, which might happen if you're including LightVolumes.cginc in other includes