### PR TITLE
Optimize the Udon code

### DIFF
--- a/Packages/red.sim.lightvolumes/UScripts/LightVolumeInstance.cs
+++ b/Packages/red.sim.lightvolumes/UScripts/LightVolumeInstance.cs
@@ -50,7 +50,7 @@ namespace VRCLightVolumes {
         // Calculates and sets invLocalEdgeBlending
         public void SetSmoothBlending(float radius) {
             Vector3 scl = transform.lossyScale;
-            InvLocalEdgeSmoothing = new Vector4(scl.x, scl.y, scl.z, 0) / Mathf.Max(radius, 0.00001f);
+            InvLocalEdgeSmoothing = scl / Mathf.Max(radius, 0.00001f);
         }
 
         // Recalculates inv TRS matrix and Relative L1 rotation

--- a/Packages/red.sim.lightvolumes/UScripts/LightVolumeInstance.cs
+++ b/Packages/red.sim.lightvolumes/UScripts/LightVolumeInstance.cs
@@ -61,8 +61,12 @@ namespace VRCLightVolumes {
 
             Matrix4x4 m = Matrix4x4.Rotate(rot);
 
-            RelativeRotationRow0 = new Vector4(m.m00, m.m01, m.m02, 0f);
-            RelativeRotationRow1 = new Vector4(m.m10, m.m11, m.m12, 0f);
+            Vector4 row0 = m.GetRow(0);
+            row0.w = 0;
+            RelativeRotationRow0 = row0;
+            Vector4 row1 = m.GetRow(1);
+            row1.w = 0;
+            RelativeRotationRow1 = row1;
 
         }
 

--- a/Packages/red.sim.lightvolumes/UScripts/LightVolumeInstance.cs
+++ b/Packages/red.sim.lightvolumes/UScripts/LightVolumeInstance.cs
@@ -55,8 +55,9 @@ namespace VRCLightVolumes {
 
         // Recalculates inv TRS matrix and Relative L1 rotation
         public void UpdateRotation() {
-            InvWorldMatrix = Matrix4x4.TRS(transform.position, transform.rotation, transform.lossyScale).inverse;
-            Quaternion rot = transform.rotation * InvBakedRotation;
+            Quaternion transformRot = transform.rotation;
+            InvWorldMatrix = Matrix4x4.TRS(transform.position, transformRot, transform.lossyScale).inverse;
+            Quaternion rot = transformRot * InvBakedRotation;
             IsRotated = Quaternion.Dot(rot, Quaternion.identity) < 0.999999f;
 
             Matrix4x4 m = Matrix4x4.Rotate(rot);

--- a/Packages/red.sim.lightvolumes/UScripts/LightVolumeManager.cs
+++ b/Packages/red.sim.lightvolumes/UScripts/LightVolumeManager.cs
@@ -97,13 +97,14 @@ namespace VRCLightVolumes {
             _additiveCount = 0;
             int maxLength = Mathf.Min(LightVolumeInstances.Length, 32);
             for (int i = 0; i < maxLength; i++) {
-                if (LightVolumeInstances[i] != null && LightVolumeInstances[i].gameObject.activeInHierarchy) {
+                LightVolumeInstance instance = LightVolumeInstances[i];
+                if (instance != null && instance.gameObject.activeInHierarchy) {
 #if UNITY_EDITOR
-                    LightVolumeInstances[i].UpdateRotation();
+                    instance.UpdateRotation();
 #else
-                    if (LightVolumeInstances[i].IsDynamic) LightVolumeInstances[i].UpdateRotation();
+                    if (instance.IsDynamic) instance.UpdateRotation();
 #endif
-                    if (LightVolumeInstances[i].IsAdditive) _additiveCount++;
+                    if (instance.IsAdditive) _additiveCount++;
                     _enabledIDs[_enabledCount] = i;
                     _enabledCount++;
                 }
@@ -120,24 +121,27 @@ namespace VRCLightVolumes {
             for (int i = 0; i < _enabledCount; i++) {
 
                 int enabledId = _enabledIDs[i];
+                int i2 = i * 2;
                 int i6 = i * 6;
 
-                _invLocalEdgeSmooth[i] = LightVolumeInstances[enabledId].InvLocalEdgeSmoothing;
-                _invWorldMatrix[i] = LightVolumeInstances[enabledId].InvWorldMatrix;
+                LightVolumeInstance instance = LightVolumeInstances[enabledId];
 
-                Vector4 c = LightVolumeInstances[enabledId].Color;
-                c.w = LightVolumeInstances[enabledId].IsRotated ? 1 : 0; // Color alpha stores if volume rotated or not
+                _invLocalEdgeSmooth[i] = instance.InvLocalEdgeSmoothing;
+                _invWorldMatrix[i] = instance.InvWorldMatrix;
+
+                Vector4 c = instance.Color;
+                c.w = instance.IsRotated ? 1 : 0; // Color alpha stores if volume rotated or not
                 _colors[i] = c;
 
-                _relativeRotations[i * 2] = LightVolumeInstances[enabledId].RelativeRotationRow0;
-                _relativeRotations[i * 2 + 1] = LightVolumeInstances[enabledId].RelativeRotationRow1;
+                _relativeRotations[i2] = instance.RelativeRotationRow0;
+                _relativeRotations[i2 + 1] = instance.RelativeRotationRow1;
 
-                _boundsUvw[i6    ] = LightVolumeInstances[enabledId].BoundsUvwMin0;
-                _boundsUvw[i6 + 1] = LightVolumeInstances[enabledId].BoundsUvwMax0;
-                _boundsUvw[i6 + 2] = LightVolumeInstances[enabledId].BoundsUvwMin1;
-                _boundsUvw[i6 + 3] = LightVolumeInstances[enabledId].BoundsUvwMax1;
-                _boundsUvw[i6 + 4] = LightVolumeInstances[enabledId].BoundsUvwMin2;
-                _boundsUvw[i6 + 5] = LightVolumeInstances[enabledId].BoundsUvwMax2;
+                _boundsUvw[i6    ] = instance.BoundsUvwMin0;
+                _boundsUvw[i6 + 1] = instance.BoundsUvwMax0;
+                _boundsUvw[i6 + 2] = instance.BoundsUvwMin1;
+                _boundsUvw[i6 + 3] = instance.BoundsUvwMax1;
+                _boundsUvw[i6 + 4] = instance.BoundsUvwMin2;
+                _boundsUvw[i6 + 5] = instance.BoundsUvwMax2;
 
             }
 

--- a/Packages/red.sim.lightvolumes/UScripts/LightVolumeManager.cs
+++ b/Packages/red.sim.lightvolumes/UScripts/LightVolumeManager.cs
@@ -38,6 +38,7 @@ namespace VRCLightVolumes {
         private Vector4[] _relativeRotations = new Vector4[0];
         private Vector4[] _colors = new Vector4[0];
         private int _additiveCount = 0;
+        private Vector4[] _bounds = new Vector4[6];
 
         private int lightVolumeInvLocalEdgeSmoothID;
         private int lightVolumeInvWorldMatrixID;
@@ -136,13 +137,14 @@ namespace VRCLightVolumes {
                 _relativeRotations[i2] = instance.RelativeRotationRow0;
                 _relativeRotations[i2 + 1] = instance.RelativeRotationRow1;
 
-                _boundsUvw[i6    ] = instance.BoundsUvwMin0;
-                _boundsUvw[i6 + 1] = instance.BoundsUvwMax0;
-                _boundsUvw[i6 + 2] = instance.BoundsUvwMin1;
-                _boundsUvw[i6 + 3] = instance.BoundsUvwMax1;
-                _boundsUvw[i6 + 4] = instance.BoundsUvwMin2;
-                _boundsUvw[i6 + 5] = instance.BoundsUvwMax2;
+                _bounds[0] = instance.BoundsUvwMin0;
+                _bounds[1] = instance.BoundsUvwMax0;
+                _bounds[2] = instance.BoundsUvwMin1;
+                _bounds[3] = instance.BoundsUvwMax1;
+                _bounds[4] = instance.BoundsUvwMin2;
+                _bounds[5] = instance.BoundsUvwMax2;
 
+                Array.Copy(_bounds, 0, _boundsUvw, i6, 6);
             }
 
         }


### PR DESCRIPTION
I've gone ahead and reduced some extern calls, bringing the main Update loop down from ~0.23ms to ~0.19ms on my system. There are however some places that can still be optimized further, although they need more consideration and maybe effort put into them. 

Here's a list of some additional improvements that could be done:
- You can probably replace the Matrix4x4.TRS() call with Transform.worldToLocalMatrix, saving 3 more extern calls in UpdateRotation.
- If the last component of the rows in the m matrix in UpdateRotation are always 0, you could remove the 2 externs that enforce it.
- You could maybe merge the first and second loops in UpdateDynamicVolumes, this would at least save 2 externs per call (loop increment and comparison), but could open up for more.
- Cross-communication for LightVolumeInstance instances could possibly be simplified to save some additional extern calls.