### PR TITLE
Make it friendly to prefab instances

### DIFF
--- a/Packages/red.sim.lightvolumes/Scripts/LVUtils.cs
+++ b/Packages/red.sim.lightvolumes/Scripts/LVUtils.cs
@@ -50,6 +50,15 @@ namespace VRCLightVolumes {
 #endif
         }
 
+        public static void MarkDirty(Object obj) {
+#if UNITY_EDITOR
+            if (EditorApplication.isPlayingOrWillChangePlaymode) return;
+            EditorUtility.SetDirty(obj);
+            if (PrefabUtility.IsPartOfPrefabInstance(obj))
+                PrefabUtility.RecordPrefabInstancePropertyModifications(obj);
+#endif
+        }
+
         // Apply voxels to a 3D Texture
         public static bool Apply3DTextureData(Texture3D texture, Color[] colors) {
             try {

--- a/Packages/red.sim.lightvolumes/Scripts/LightVolumeSetup.cs
+++ b/Packages/red.sim.lightvolumes/Scripts/LightVolumeSetup.cs
@@ -210,17 +210,22 @@ namespace VRCLightVolumes {
 
         for (int i = 0; i < LightVolumes.Count; i++) {
 
-            if (LightVolumes[i] == null || LightVolumes[i].LightVolumeInstance == null) continue;
+            if (LightVolumes[i] == null) continue;
+            var lightVolumeInstance = LightVolumes[i].LightVolumeInstance;
 
-            LightVolumes[i].LightVolumeInstance.BoundsUvwMin0 = atlas.BoundsUvwMin[i * 3];
-            LightVolumes[i].LightVolumeInstance.BoundsUvwMin1 = atlas.BoundsUvwMin[i * 3 + 1];
-            LightVolumes[i].LightVolumeInstance.BoundsUvwMin2 = atlas.BoundsUvwMin[i * 3 + 2];
+            if (lightVolumeInstance == null) continue;
 
-            LightVolumes[i].LightVolumeInstance.BoundsUvwMax0 = atlas.BoundsUvwMax[i * 3];
-            LightVolumes[i].LightVolumeInstance.BoundsUvwMax1 = atlas.BoundsUvwMax[i * 3 + 1];
-            LightVolumes[i].LightVolumeInstance.BoundsUvwMax2 = atlas.BoundsUvwMax[i * 3 + 2];
+            lightVolumeInstance.BoundsUvwMin0 = atlas.BoundsUvwMin[i * 3];
+            lightVolumeInstance.BoundsUvwMin1 = atlas.BoundsUvwMin[i * 3 + 1];
+            lightVolumeInstance.BoundsUvwMin2 = atlas.BoundsUvwMin[i * 3 + 2];
 
-            LightVolumeDataList.Add(new LightVolumeData(i < LightVolumesWeights.Count ? LightVolumesWeights[i] : 0, LightVolumes[i].LightVolumeInstance));
+            lightVolumeInstance.BoundsUvwMax0 = atlas.BoundsUvwMax[i * 3];
+            lightVolumeInstance.BoundsUvwMax1 = atlas.BoundsUvwMax[i * 3 + 1];
+            lightVolumeInstance.BoundsUvwMax2 = atlas.BoundsUvwMax[i * 3 + 2];
+
+            LightVolumeDataList.Add(new LightVolumeData(i < LightVolumesWeights.Count ? LightVolumesWeights[i] : 0, lightVolumeInstance));
+
+            LVUtils.MarkDirty(lightVolumeInstance);
         }
 
         LVUtils.SaveTexture3DAsAsset(atlas.Texture, $"{Path.GetDirectoryName(SceneManager.GetActiveScene().path)}/{SceneManager.GetActiveScene().name}/LightVolumeAtlas.asset");


### PR DESCRIPTION
If the light volume component/game object is part of prefab instance, the automatic setup tool will fails to write changes to the components, which causes issues like these:
- Light volume forgot that bakery volume was created and try to recreate it again and again.
- Bakery volume object vanished on bake button pressed in some cases.
- The bounding box doesn't properly recorded on packing atlas and causes the prefabbed volume has no effects.

This issue frustrated me for several hours last night and finally figure out the root cause.