### PR TITLE
Rename enum in non-Bakery branch

### DIFF
--- a/Packages/red.sim.lightvolumes/Scripts/LightVolumeSetup.cs
+++ b/Packages/red.sim.lightvolumes/Scripts/LightVolumeSetup.cs
@@ -20,7 +20,7 @@ namespace VRCLightVolumes {
 #if BAKERY_INCLUDED
     public Baking BakingMode = Baking.Bakery;
 #else
-        public Baking BakingMode = Baking.UnityLightmapper;
+        public Baking BakingMode = Baking.Progressive;
 #endif
         [Tooltip("Removes baked noise in Light Volumes but may slightly reduce sharpness. Recommended to keep it enabled.")]
         public bool Denoise = true;


### PR DESCRIPTION
Enum usage was causing exceptions. Seems to have been a rename missed in 6e2ae40afa2f22dec1b7ced5f3e4e699c9d7a4f5