### PR TITLE
Add variant of specular functions which take specular colour directly. 

### DIFF
--- a/Documentation/ForShaderDevelopers.md
+++ b/Documentation/ForShaderDevelopers.md
@@ -146,6 +146,14 @@ float3 LightVolumeSpecular(float3 albedo, float smoothness, float metallic, floa
 
 `out float3 L1r`, `out float3 L1g`, `out float3 L1b` - Outputs vectors that stores the Red, Green and Blue light directions and power, as a magnitude of these vectors.
 
+You can also provide the surface's specular color directly.
+
+```
+float3 LightVolumeSpecular(float3 specColor, float3 worldNormal, float3 viewDir, float3 L0, float3 L1r, float3 L1g, float3 L1b)
+```
+
+`float3 specColor` - Final surface specular color
+
 ### float3 LightVolumeSpecularDominant()
 Calculates approximated speculars based on SH components. Can be used with Light Volumes or even with any other SH L1 values, like Unity default light probes. The result should be added to the final color, just like emission. You should NOT multiply this by albedo color!
 
@@ -168,6 +176,14 @@ float3 LightVolumeSpecularDominant(float3 albedo, float smoothness, float metall
 `out float3 L0` - Outputs ambient color of the current fragment.
 
 `out float3 L1r`, `out float3 L1g`, `out float3 L1b` - Outputs vectors that stores the Red, Green and Blue light directions and power, as a magnitude of these vectors.
+
+You can also provide the surface's specular color directly.
+
+```
+float3 LightVolumeSpecularDominant(float3 specColor, float3 worldNormal, float3 viewDir, float3 L0, float3 L1r, float3 L1g, float3 L1b)
+```
+
+`float3 specColor` - Final surface specular color
 
 ### float \_UdonLightVolumeEnabled
 A global float variable that is not defined and stores `0` if there are no light volumes support on the current scene, or stores `1` if light volumes system is provided.

--- a/Packages/red.sim.lightvolumes/Shaders/LightVolumes.cginc
+++ b/Packages/red.sim.lightvolumes/Shaders/LightVolumes.cginc
@@ -145,7 +145,7 @@ float3 LV_Normalize(float3 v) {
 }
 
 // Calculates speculars for light volumes or any SH L1 data
-float3 LightVolumeSpecular(float3 albedo, float smoothness, float metallic, float3 worldNormal, float3 viewDir, float3 L0, float3 L1r, float3 L1g, float3 L1b) {
+float3 LightVolumeSpecular(float3 f0, float smoothness, float3 worldNormal, float3 viewDir, float3 L0, float3 L1r, float3 L1g, float3 L1b) {
     
     float3 specColor = max(float3(dot(reflect(-L1r, worldNormal), viewDir), dot(reflect(-L1g, worldNormal), viewDir), dot(reflect(-L1b, worldNormal), viewDir)), 0);
     
@@ -164,7 +164,6 @@ float3 LightVolumeSpecular(float3 albedo, float smoothness, float metallic, floa
     float gSpec = LV_DistributionGGX(gNh, roughExp);
     float bSpec = LV_DistributionGGX(bNh, roughExp);
     
-    float3 f0 = lerp(0.04f, albedo, metallic);
     float3 specs = (rSpec + gSpec + bSpec) * f0;
     float3 coloredSpecs = specs * specColor;
     
@@ -175,8 +174,14 @@ float3 LightVolumeSpecular(float3 albedo, float smoothness, float metallic, floa
     
 }
 
+float3 LightVolumeSpecular(float3 albedo, float smoothness, float metallic, float3 worldNormal, float3 viewDir, float3 L0, float3 L1r, float3 L1g, float3 L1b) {
+    
+    float3 specularf0 = lerp(0.04f, albedo, metallic);
+    return LightVolumeSpecular(specularf0, smoothness, worldNormal, viewDir, L0, L1r, L1g, L1b);
+}
+
 // Calculates speculars for light volumes or any SH L1 data, but simplified, with only one dominant direction
-float3 LightVolumeSpecularDominant(float3 albedo, float smoothness, float metallic, float3 worldNormal, float3 viewDir, float3 L0, float3 L1r, float3 L1g, float3 L1b) {
+float3 LightVolumeSpecularDominant(float3 f0, float smoothness, float3 worldNormal, float3 viewDir, float3 L0, float3 L1r, float3 L1g, float3 L1b) {
     
     float3 dominantDir = L1r + L1g + L1b;
     float3 dir = LV_Normalize(LV_Normalize(dominantDir) + viewDir);
@@ -187,8 +192,14 @@ float3 LightVolumeSpecularDominant(float3 albedo, float smoothness, float metall
     
     float spec = LV_DistributionGGX(nh, roughExp);
     
-    return max(spec * L0 * lerp(0.04f, albedo, metallic), 0.0) * 2;
+    return max(spec * L0 * f0, 0.0) * 2;
     
+}
+
+float3 LightVolumeSpecularDominant(float3 albedo, float smoothness, float metallic, float3 worldNormal, float3 viewDir, float3 L0, float3 L1r, float3 L1g, float3 L1b) {
+    
+    float3 specularf0 = lerp(0.04f, albedo, metallic);
+    return LightVolumeSpecularDominant(specularf0, smoothness, worldNormal, viewDir, L0, L1r, L1g, L1b);
 }
 
 // Calculate Light Volume Color based on all SH components provided and the world normal


### PR DESCRIPTION
Adds versions of LightVolumeSpecular and LightVolumeSpecularDominant which take f0 instead of albedo and metallic and reroutes the existing ones to them. Also added to documentation. 