### PR TITLE
Fix #24

### DIFF
--- a/Packages/red.sim.lightvolumes/Scripts/Texture3DAtlasGenerator.cs
+++ b/Packages/red.sim.lightvolumes/Scripts/Texture3DAtlasGenerator.cs
@@ -101,6 +101,13 @@ namespace VRCLightVolumes {
                                 if (x < p.x + p.w && x + bw > p.x && y < p.y + p.h && y + bh > p.y && z < p.z + p.d && z + bd > p.z) {
                                     collides = true; break;
                                 }
+
+                                // Check for out of bounds of the texture3D
+                                int t3dMax = 2048;
+                                if (x + bw > t3dMax || y + bh > t3dMax || z + bd > t3dMax)
+                                {
+                                    collides = true; break;
+                                }
                             }
                             if (collides) continue;
 


### PR DESCRIPTION
Requires further testing.

Adds a check when packing to make sure the texture3D does not exceed the allowed limit of 2048x

This is probably not optimal but will at least prevent the script from crashing.