### PR TITLE
Area light support

### DIFF
--- a/Packages/red.sim.lightvolumes/Scripts/Editor/PointLightVolumeEditor.cs
+++ b/Packages/red.sim.lightvolumes/Scripts/Editor/PointLightVolumeEditor.cs
@@ -28,6 +28,16 @@ namespace VRCLightVolumes {
                 hiddenFields.Add("Falloff");
             }
 
+            if (PointLightVolume.Type == PointLightVolume.LightType.AreaLight) {
+                hiddenFields.Add("Angle");
+                hiddenFields.Add("Falloff");
+                hiddenFields.Add("Shape");
+                hiddenFields.Add("Range");
+            } else {
+                hiddenFields.Add("AreaLightWidth");
+                hiddenFields.Add("AreaLightHeight");
+            }
+
             if (PointLightVolume.Shape == PointLightVolume.LightShape.Parametric) {
                 hiddenFields.Add("FalloffLUT");
                 hiddenFields.Add("Cubemap");
@@ -67,7 +77,7 @@ namespace VRCLightVolumes {
                 Handles.color = new Color(1f, 1f, 0f, 0.15f);
                 DrawPointLight(origin, range);
 
-            } else { // Spot Light Visualization
+            } else if (pointLightVolume.Type == PointLightVolume.LightType.SpotLight) { // Spot Light Visualization
 
                 // Calculating
 
@@ -92,6 +102,16 @@ namespace VRCLightVolumes {
                 Handles.color = new Color(1f, 1f, 0f, 0.15f);
                 DrawSpotLight(origin, diskCenter, forward, radius, dirs);
 
+            } else { // Area light
+                
+                Handles.zTest = UnityEngine.Rendering.CompareFunction.LessEqual;
+                Handles.color = new Color(1f, 1f, 0f, 0.6f);
+                DrawAreaLight(origin, t.rotation, pointLightVolume.AreaLightWidth, pointLightVolume.AreaLightHeight);
+
+                Handles.zTest = UnityEngine.Rendering.CompareFunction.Greater;
+                Handles.color = new Color(1f, 1f, 0f, 0.15f);
+                DrawAreaLight(origin, t.rotation, pointLightVolume.AreaLightWidth, pointLightVolume.AreaLightHeight);
+                
             }
 
         }
@@ -119,6 +139,26 @@ namespace VRCLightVolumes {
             Handles.DrawWireArc(center, Vector3.right, Vector3.up, 360, radius);
             Handles.DrawWireArc(center, Vector3.up, Vector3.forward, 360, radius);
             Handles.DrawWireArc(center, Vector3.forward, Vector3.right, 360, radius);
+        }
+
+        private void DrawAreaLight(Vector3 center, Quaternion rotation, float width, float height) {
+            Vector3 right = rotation * Vector3.right * (width * 0.5f);
+            Vector3 up = rotation * Vector3.up * (height * 0.5f);
+
+            Vector3[] corners = new Vector3[4];
+            corners[0] = center + right + up; // Top Right
+            corners[1] = center - right + up; // Top Left
+            corners[2] = center - right - up; // Bottom Left
+            corners[3] = center + right - up; // Bottom Right
+
+            // Draw the rectangle
+            Handles.DrawLine(corners[0], corners[1]);
+            Handles.DrawLine(corners[1], corners[2]);
+            Handles.DrawLine(corners[2], corners[3]);
+            Handles.DrawLine(corners[3], corners[0]);
+            
+            // Draw forward vector
+            Handles.DrawLine(center, center + rotation * Vector3.forward * 0.5f);
         }
 
     }

--- a/Packages/red.sim.lightvolumes/Scripts/PointLightVolume.cs
+++ b/Packages/red.sim.lightvolumes/Scripts/PointLightVolume.cs
@@ -15,6 +15,8 @@ namespace VRCLightVolumes {
         public LightShape Shape = LightShape.Parametric;
         [Range(0.1f, 360)] public float Angle = 60f;
         [Range(0.001f, 1)] public float Falloff = 1f;
+        [Min(0)] public float AreaLightWidth = 1f;
+        [Min(0)] public float AreaLightHeight = 1f;
         public Texture2D FalloffLUT = null;
         public Cubemap Cubemap = null;
 
@@ -65,9 +67,9 @@ namespace VRCLightVolumes {
             SetupDependencies();
             PointLightVolumeInstance.IsDynamic = Dynamic;
             PointLightVolumeInstance.SetColor(Color, Intensity);
-            PointLightVolumeInstance.SetRange(Range);
 
             if(Type == LightType.PointLight) { // Point light
+                PointLightVolumeInstance.SetRange(Range);
                 if (Shape == LightShape.Custom && Cubemap != null) {
                     PointLightVolumeInstance.SetCustomTexture(CustomID); // Use Custom Cubemap Texture
                 } else if (Shape == LightShape.LUT && FalloffLUT != null) {
@@ -76,7 +78,8 @@ namespace VRCLightVolumes {
                     PointLightVolumeInstance.SetParametric(); // Use this light in parametric mode
                 }
                 PointLightVolumeInstance.SetPointLight(); // Use it as Point Light
-            } else { // Spot Light
+            } else if (Type == LightType.SpotLight) { // Spot Light
+                PointLightVolumeInstance.SetRange(Range);
                 if (Shape == LightShape.Custom && FalloffLUT != null) {
                     PointLightVolumeInstance.SetCustomTexture(CustomID); // Use Custom Projection Texture
                 } else if (Shape == LightShape.LUT && FalloffLUT != null) {
@@ -85,6 +88,8 @@ namespace VRCLightVolumes {
                     PointLightVolumeInstance.SetParametric(); // Use this light in parametric mode
                 }
                 PointLightVolumeInstance.SetSpotLight(Angle, Falloff); // Don't use custom tex
+            } else if (Type == LightType.AreaLight) { // Area light
+                PointLightVolumeInstance.SetAreaLight(AreaLightWidth, AreaLightHeight);
             }
 
             LVUtils.MarkDirty(PointLightVolumeInstance);
@@ -134,7 +139,8 @@ namespace VRCLightVolumes {
 
         public enum LightType {
             PointLight,
-            SpotLight
+            SpotLight,
+            AreaLight,
         }
 
     }

--- a/Packages/red.sim.lightvolumes/Shaders/LightVolumes.cginc
+++ b/Packages/red.sim.lightvolumes/Shaders/LightVolumes.cginc
@@ -2,8 +2,6 @@
 #define VRC_LIGHT_VOLUMES_INCLUDED
 #define VRCLV_VERSION 2
 
-#pragma skip_optimizations d3d11
-
 // Makes it possible to sample Texcure Cube Arrays in surface shaders. Thanks to error.mdl!
 #if defined(SHADER_TARGET_SURFACE_ANALYSIS_MOJOSHADER)
     #define UNITY_DECLARE_TEXCUBEARRAY(tex) samplerCUBE tex

--- a/Packages/red.sim.lightvolumes/UScripts/PointLightVolumeInstance.cs
+++ b/Packages/red.sim.lightvolumes/UScripts/PointLightVolumeInstance.cs
@@ -26,6 +26,16 @@ namespace VRCLightVolumes {
         public bool IsSpotLight() {
             return PositionData.w < 0;
         }
+        
+        // Checks if it's a point light
+        public bool IsPointLight() {
+            return PositionData.w >= 0 && ColorData.w <= 1.5;
+        }
+
+        // Checks if it's an area light
+        public bool IsAreaLight() {
+            return PositionData.w >= 0 && ColorData.w > 1.5;
+        }
 
         // Checks if uses custom texture
         public bool IsCustomTexture() {
@@ -94,6 +104,12 @@ namespace VRCLightVolumes {
             }
             PositionData.w = - Mathf.Abs(PositionData.w);
         }
+        
+        // Sets light into the area light type
+        public void SetAreaLight(float width, float height) {
+            PositionData.w = width;
+            ColorData.w = 2 + height; // Add 2 to get out of [-1; 1] codomain of cosine
+        }
 
         // Sets color
         public void SetColor(Color color, float intensity) {
@@ -107,7 +123,10 @@ namespace VRCLightVolumes {
             Vector3 pos = transform.position;
             PositionData = new Vector4(pos.x, pos.y, pos.z, PositionData.w);
 
-            if (IsSpotLight() && !IsCustomTexture()) { // If Spot Light with no cookie
+            if (IsAreaLight()) {
+                Quaternion rot = transform.rotation;
+                DirectionData = new Vector4(rot.x, rot.y, rot.z, rot.w);
+            } if (IsSpotLight() && !IsCustomTexture()) { // If Spot Light with no cookie
                 Vector3 dir = transform.forward;
                 DirectionData = new Vector4(dir.x, dir.y, dir.z, DirectionData.w);
             } else if (!IsParametric()) { // If Point Light with a cubemap or a spot light with cookie


### PR DESCRIPTION
Adds support for quad/area lights using the technique described in https://cseweb.ucsd.edu/~ravir/ash.pdf

Notes:
- I took the approach of trying to reuse the existing uniforms and not add anything new. Area lights are considered just another light type like point and spot.
- I've tried to optimize the code using the assumption that we only have 4 vertices, and only want to compute L1 SH.
- I don't currently do any kind of culling for area lights, so if you have more than the "max overdraw amount", no more lights will be applied. That isn't great, but it isn't really clear to me how to apply a non-physical range to area lights like with the other light types. You could just scale the SH coefficient based on distance, but I think it won't look good. Ideally the cutoff range should be computed from the size of the light.. I'll have to think about it a bit more.