### PR TITLE
Add simple dilation

### DIFF
--- a/Packages/red.sim.lightvolumes/Scripts/LightVolume.cs
+++ b/Packages/red.sim.lightvolumes/Scripts/LightVolume.cs
@@ -234,7 +234,21 @@ namespace VRCLightVolumes {
                 {
                     float[] validity = probesValidity.ToArray();
                     
-                    for (int iter = 0; iter < LightVolumeSetup.DilationIterations; iter++)
+                    // Outputs
+                    float[] validityDilated = new float[vCount];
+                    Vector3[] L0Dilated = new Vector3[vCount];
+                    Vector3[] L1rDilated = new Vector3[vCount];
+                    Vector3[] L1gDilated = new Vector3[vCount];
+                    Vector3[] L1bDilated = new Vector3[vCount];
+                    
+                    // Initialize outputs with source data
+                    System.Array.Copy(validity, validityDilated, vCount);
+                    System.Array.Copy(L0, L0Dilated, vCount);
+                    System.Array.Copy(L1r, L1rDilated, vCount);
+                    System.Array.Copy(L1g, L1gDilated, vCount);
+                    System.Array.Copy(L1b, L1bDilated, vCount);
+                    
+                    for (int iter = 0; iter < LightVolumeSetup.DilationIterations; iter++) {
                         for (int voxelZ = 0; voxelZ < d; voxelZ++)
                             for (int voxelY = 0; voxelY < h; voxelY++)
                                 for (int voxelX = 0; voxelX < w; voxelX++) {
@@ -267,13 +281,21 @@ namespace VRCLightVolumes {
                                             }
 
                                     if (validCount > 0) {
-                                        L0[centerIdx] = L0Sum / validCount;
-                                        L1r[centerIdx] = L1rSum / validCount;
-                                        L1g[centerIdx] = L1gSum / validCount;
-                                        L1b[centerIdx] = L1bSum / validCount;
-                                        validity[centerIdx] = 0.0f;
+                                        L0Dilated[centerIdx] = L0Sum / validCount;
+                                        L1rDilated[centerIdx] = L1rSum / validCount;
+                                        L1gDilated[centerIdx] = L1gSum / validCount;
+                                        L1bDilated[centerIdx] = L1bSum / validCount;
+                                        validityDilated[centerIdx] = 0.0f;
                                     }
                                 }
+                        
+                        // Copy outputs back to source data after each iteration
+                        System.Array.Copy(validityDilated, validity, vCount);
+                        System.Array.Copy(L0Dilated, L0, vCount);
+                        System.Array.Copy(L1rDilated, L1r, vCount);
+                        System.Array.Copy(L1gDilated, L1g, vCount);
+                        System.Array.Copy(L1bDilated, L1b, vCount);
+                    }
                 }
 
                 // Denoising

--- a/Packages/red.sim.lightvolumes/Scripts/LightVolume.cs
+++ b/Packages/red.sim.lightvolumes/Scripts/LightVolume.cs
@@ -217,7 +217,7 @@ namespace VRCLightVolumes {
                 const int z = 2;
                 const float coeff = 1.65f; // To transform to bakery non-linear data format. Should be 1.7699115f actually
 
-                // Separating data for denoising
+                // Separating data for dilation and denoising
                 Vector3[] L0 = new Vector3[vCount];
                 Vector3[] L1r = new Vector3[vCount];
                 Vector3[] L1g = new Vector3[vCount];
@@ -227,6 +227,53 @@ namespace VRCLightVolumes {
                     L1r[i] = new Vector3(probes[i][r, x], probes[i][r, y], probes[i][r, z]);
                     L1g[i] = new Vector3(probes[i][g, x], probes[i][g, y], probes[i][g, z]);
                     L1b[i] = new Vector3(probes[i][b, x], probes[i][b, y], probes[i][b, z]);
+                }
+                
+                // Dilation
+                if (LightVolumeSetup.DilateInvalidProbes)
+                {
+                    float[] validity = probesValidity.ToArray();
+                    
+                    for (int iter = 0; iter < LightVolumeSetup.DilationIterations; iter++)
+                        for (int voxelZ = 0; voxelZ < d; voxelZ++)
+                            for (int voxelY = 0; voxelY < h; voxelY++)
+                                for (int voxelX = 0; voxelX < w; voxelX++) {
+                                    int centerIdx = voxelX + voxelY * w + voxelZ * w * h;
+
+                                    if (validity[centerIdx] < LightVolumeSetup.BackfaceTolerance) continue;
+                                    
+                                    Vector3 L0Sum = Vector3.zero;
+                                    Vector3 L1rSum = Vector3.zero;
+                                    Vector3 L1gSum = Vector3.zero;
+                                    Vector3 L1bSum = Vector3.zero;
+                                    int validCount = 0;
+                                    for (int dz = -1; dz <= 1; dz++)
+                                        for (int dy = -1; dy <= 1; dy++)
+                                            for (int dx = -1; dx <= 1; dx++) {
+                                                int xx = voxelX + dx;
+                                                int yy = voxelY + dy;
+                                                int zz = voxelZ + dz;
+                                                if (xx < 0 || yy < 0 || zz < 0 || xx >= w || yy >= h || zz >= d) continue;
+
+                                                int nIdx = xx + yy * w + zz * w * h;
+                                                float neighborValidity = validity[nIdx];
+                                                if (neighborValidity < LightVolumeSetup.BackfaceTolerance) {
+                                                    validCount++;
+                                                    L0Sum += L0[nIdx];
+                                                    L1rSum += L1r[nIdx];
+                                                    L1gSum += L1g[nIdx];
+                                                    L1bSum += L1b[nIdx];
+                                                }
+                                            }
+
+                                    if (validCount > 0) {
+                                        L0[centerIdx] = L0Sum / validCount;
+                                        L1r[centerIdx] = L1rSum / validCount;
+                                        L1g[centerIdx] = L1gSum / validCount;
+                                        L1b[centerIdx] = L1bSum / validCount;
+                                        validity[centerIdx] = 0.0f;
+                                    }
+                                }
                 }
 
                 // Denoising

--- a/Packages/red.sim.lightvolumes/Scripts/LightVolumeSetup.cs
+++ b/Packages/red.sim.lightvolumes/Scripts/LightVolumeSetup.cs
@@ -24,6 +24,15 @@ namespace VRCLightVolumes {
 #endif
         [Tooltip("Removes baked noise in Light Volumes but may slightly reduce sharpness. Recommended to keep it enabled.")]
         public bool Denoise = true;
+        [Header("Dilation")]
+        [Tooltip("Whether to dilate valid probe data into invalid probes, such as probes that are inside geometry. Helps mitigate light leaking.")]
+        public bool DilateInvalidProbes = true;
+        [Tooltip("How many iterations to run dilation for. Higher values will result in less leaking, but will also cause longer bakes.")]
+        [Range(1, 8)]
+        public int DilationIterations = 2;
+        [Tooltip("The percentage of rays shot from a probe that should hit backfaces before the probe is considered invalid for the purpose of dilation. 0 means every probe is invalid, 1 means every probe is valid.")] 
+        [Range(0, 1)]
+        public float BackfaceTolerance = 0.1f;
         [Tooltip("Automatically fixes Bakery's \"burned\" light probes after a scene bake. But decreases their contrast slightly.")]
         public bool FixLightProbesL1 = true;
         [Header("Visuals")]

--- a/Packages/red.sim.lightvolumes/Scripts/LightVolumeSetup.cs
+++ b/Packages/red.sim.lightvolumes/Scripts/LightVolumeSetup.cs
@@ -29,7 +29,7 @@ namespace VRCLightVolumes {
         public bool DilateInvalidProbes = true;
         [Tooltip("How many iterations to run dilation for. Higher values will result in less leaking, but will also cause longer bakes.")]
         [Range(1, 8)]
-        public int DilationIterations = 2;
+        public int DilationIterations = 1;
         [Tooltip("The percentage of rays shot from a probe that should hit backfaces before the probe is considered invalid for the purpose of dilation. 0 means every probe is invalid, 1 means every probe is valid.")] 
         [Range(0, 1)]
         public float BackfaceTolerance = 0.1f;


### PR DESCRIPTION
Adds a simple technique for mitigating light leaks as mentioned in https://github.com/REDSIM/VRCLightVolumes/issues/38#issuecomment-2960575435

For every invalid probe, average it's valid neighbors, and replace the probes data with the average. This can be repeated multiple times, in effect averaging probes from further and further away. Usually 1 or 2 iterations is enough for most of the effect.

Behold, a monkey lit by a Light Volume, with ugly leaking:
![u2IdvNcz2d](https://github.com/user-attachments/assets/774a32eb-59d3-4644-8ac6-6a904ea37d06)

With dilation enabled (default settings), no more leaking :)
![bQDCbTvEVG](https://github.com/user-attachments/assets/a1107f03-5cb9-4191-bee0-6a308bedb8d2)

It's not a perfect solution (see the other approaches I mentioned in the issue), but it's the easiest to implement and has good bang for the buck.

P.S. I haven't tested with Bakery as I don't own it.