### PR TITLE
Atlas post-processing CRT support, some cleanups, and some hooks for external scripts

### DIFF
--- a/Packages/red.sim.lightvolumes/Scripts/Editor/LightVolumeEditor.cs
+++ b/Packages/red.sim.lightvolumes/Scripts/Editor/LightVolumeEditor.cs
@@ -175,7 +175,7 @@ namespace VRCLightVolumes {
             Handles.matrix = Matrix4x4.identity;
         }
 
-        private void OnSceneGUI() {
+        protected void OnSceneGUI() {
 
             // Drawing bounds for each of selected light volumes
             foreach (var obj in Selection.gameObjects) {

--- a/Packages/red.sim.lightvolumes/Scripts/Editor/LightVolumeSetupEditor.cs
+++ b/Packages/red.sim.lightvolumes/Scripts/Editor/LightVolumeSetupEditor.cs
@@ -245,12 +245,15 @@ namespace VRCLightVolumes {
             }
 
             ulong vCount = 0;
-            if (_lightVolumeSetup.LightVolumeManager != null && _lightVolumeSetup.LightVolumeManager.LightVolumeAtlas != null) {
-                var tex = _lightVolumeSetup.LightVolumeManager.LightVolumeAtlas;
-                if (tex is Texture3D tex3D)
-                    vCount = (ulong)tex.width * (ulong)tex.height * (ulong)tex3D.depth;
-                else if (tex is CustomRenderTexture crt && crt.volumeDepth > 0)
-                    vCount = (ulong)crt.width * (ulong)crt.height * (ulong)crt.volumeDepth;
+            if (_lightVolumeSetup.LightVolumeManager != null && _lightVolumeSetup.LightVolumeManager.LightVolumeAtlasBase != null) {
+                var tex = _lightVolumeSetup.LightVolumeManager.LightVolumeAtlasBase;
+                vCount = (ulong)tex.width * (ulong)tex.height * (ulong)tex.depth;
+
+                foreach (var crt in _lightVolumeSetup.LightVolumeManager.AtlasPostProcessors) {
+                    if (crt != null) {
+                        vCount += (ulong)crt.width * (ulong)crt.height * (ulong)crt.volumeDepth;
+                    }
+                }
             }
 
             GUILayout.Label($"Atlas size in VRAM: {SizeInVRAM(vCount)} MB");

--- a/Packages/red.sim.lightvolumes/Scripts/Editor/LightVolumeSetupEditor.cs
+++ b/Packages/red.sim.lightvolumes/Scripts/Editor/LightVolumeSetupEditor.cs
@@ -247,7 +247,10 @@ namespace VRCLightVolumes {
             ulong vCount = 0;
             if (_lightVolumeSetup.LightVolumeManager != null && _lightVolumeSetup.LightVolumeManager.LightVolumeAtlas != null) {
                 var tex = _lightVolumeSetup.LightVolumeManager.LightVolumeAtlas;
-                vCount = (ulong)tex.width * (ulong)tex.height * (ulong)tex.depth;
+                if (tex is Texture3D tex3D)
+                    vCount = (ulong)tex.width * (ulong)tex.height * (ulong)tex3D.depth;
+                else if (tex is CustomRenderTexture crt && crt.volumeDepth > 0)
+                    vCount = (ulong)crt.width * (ulong)crt.height * (ulong)crt.volumeDepth;
             }
 
             GUILayout.Label($"Atlas size in VRAM: {SizeInVRAM(vCount)} MB");

--- a/Packages/red.sim.lightvolumes/Scripts/Texture3DAtlasGenerator.cs
+++ b/Packages/red.sim.lightvolumes/Scripts/Texture3DAtlasGenerator.cs
@@ -16,12 +16,16 @@ namespace VRCLightVolumes {
 
         const int maxAtlasSize = 2048;
 
+        public static event Action<LightVolume[]> OnPreAtlasCreate;
+
         public static IEnumerator CreateAtlas(LightVolume[] volumes, Action<Atlas3D> onComplete) {
 
             Texture3D[] texs = null;
             const int padding = 1;
 
             try {
+
+                OnPreAtlasCreate?.Invoke(volumes);
 
                 // Stacking textures into array
                 Texture3D[] textures = new Texture3D[volumes.Length * 4];

--- a/Packages/red.sim.lightvolumes/UScripts/LightVolumeManager.cs
+++ b/Packages/red.sim.lightvolumes/UScripts/LightVolumeManager.cs
@@ -17,8 +17,12 @@ namespace VRCLightVolumes {
 #endif
     {
         public const float Version = 2; // VRC Light Volumes Current version. This value used in shaders (_UdonLightVolumeEnabled) to determine which features are can be used
-        [Tooltip("Combined Texture3D containing all Light Volumes' textures.")]
+        [Tooltip("Combined texture containing all Light Volumes' textures.")]
         public Texture LightVolumeAtlas;
+        [Tooltip("Combined Texture3D containing all baked Light Volume data. This field is not used at runtime, see LightVolumeAtlas instead. It specifies the base for the post process chain, if given.")]
+        public Texture3D LightVolumeAtlasBase;
+        [Tooltip("Custom Render Textures that will be applied top to bottom to the Light Volume Atlas at runtime. External scripts can register themselves here using `RegisterPostProcessorCRT`. You probably don't want to mess with this field manually.")]
+        public CustomRenderTexture[] AtlasPostProcessors;
         [Tooltip("When enabled, areas outside Light Volumes fall back to light probes. Otherwise, the Light Volume with the smallest weight is used as fallback. It also improves performance.")]
         public bool LightProbesBlending = true;
         [Tooltip("Disables smooth blending with areas outside Light Volumes. Use it if your entire scene's play area is covered by Light Volumes. It also improves performance.")]

--- a/Packages/red.sim.lightvolumes/UScripts/LightVolumeManager.cs
+++ b/Packages/red.sim.lightvolumes/UScripts/LightVolumeManager.cs
@@ -154,7 +154,6 @@ namespace VRCLightVolumes {
             // Light Volumes
             lightVolumeInvLocalEdgeSmoothID = VRCShader.PropertyToID("_UdonLightVolumeInvLocalEdgeSmooth");
             lightVolumeInvWorldMatrixID = VRCShader.PropertyToID("_UdonLightVolumeInvWorldMatrix");
-            lightVolumeUvwID = VRCShader.PropertyToID("_UdonLightVolumeUvw");
             lightVolumeColorID = VRCShader.PropertyToID("_UdonLightVolumeColor");
             lightVolumeCountID = VRCShader.PropertyToID("_UdonLightVolumeCount");
             lightVolumeAdditiveCountID = VRCShader.PropertyToID("_UdonLightVolumeAdditiveCount");

--- a/Packages/red.sim.lightvolumes/UScripts/LightVolumeManager.cs
+++ b/Packages/red.sim.lightvolumes/UScripts/LightVolumeManager.cs
@@ -18,7 +18,7 @@ namespace VRCLightVolumes {
     {
         public const float Version = 2; // VRC Light Volumes Current version. This value used in shaders (_UdonLightVolumeEnabled) to determine which features are can be used
         [Tooltip("Combined Texture3D containing all Light Volumes' textures.")]
-        public Texture3D LightVolumeAtlas;
+        public Texture LightVolumeAtlas;
         [Tooltip("When enabled, areas outside Light Volumes fall back to light probes. Otherwise, the Light Volume with the smallest weight is used as fallback. It also improves performance.")]
         public bool LightProbesBlending = true;
         [Tooltip("Disables smooth blending with areas outside Light Volumes. Use it if your entire scene's play area is covered by Light Volumes. It also improves performance.")]

--- a/Packages/red.sim.lightvolumes/UScripts/LightVolumeManager.cs
+++ b/Packages/red.sim.lightvolumes/UScripts/LightVolumeManager.cs
@@ -73,6 +73,10 @@ namespace VRCLightVolumes {
         private Vector4[] _boundsScale = new Vector4[3];
         private Vector4[] _bounds = new Vector4[6]; // Legacy
 
+        // Public API for other U# scripts
+        public int EnabledCount => _enabledCount;
+        public int[] EnabledIDs => _enabledIDs;
+
         #region Shader Property IDs
         // Light Volumes
         private int lightVolumeInvLocalEdgeSmoothID;
@@ -164,7 +168,6 @@ namespace VRCLightVolumes {
             lightVolumeSharpBoundsID = VRCShader.PropertyToID("_UdonLightVolumeSharpBounds");
             lightVolumeID = VRCShader.PropertyToID("_UdonLightVolume");
             lightVolumeRotationQuaternionID = VRCShader.PropertyToID("_UdonLightVolumeRotationQuaternion");
-            lightVolumeInvWorldMatrixID = VRCShader.PropertyToID("_UdonLightVolumeInvWorldMatrix");
             lightVolumeUvwScaleID = VRCShader.PropertyToID("_UdonLightVolumeUvwScale");
             lightVolumeOcclusionUvwID = VRCShader.PropertyToID("_UdonLightVolumeOcclusionUvw");
             lightVolumeOcclusionCountID = VRCShader.PropertyToID("_UdonLightVolumeOcclusionCount");


### PR DESCRIPTION
As I'm writing my LTCGI plugin for Light Volumes, I exposed and cleaned up a few things, and most importantly added a new C# API to register 3D Custom Render Textures as realtime "post processors" for the base atlas. I could of course manage my CRT all externally, but I figured I might as well write that code here so other folks can add their own external hooks and they won't all step on each other's toes.

Let me know what you think. Individual commits have some extra notes.