### PR TITLE
Add Editor scene view preview for light volumes.

### DIFF
--- a/Packages/red.sim.lightvolumes/Scripts/Editor/LightVolumePreview.cs
+++ b/Packages/red.sim.lightvolumes/Scripts/Editor/LightVolumePreview.cs
@@ -1,0 +1,79 @@
+
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEngine;
+
+namespace VRCLightVolumes {
+	
+    [InitializeOnLoad]
+    sealed class SceneLightVolumeL0Mode
+    {
+        static class Cache
+        {
+            public static readonly Shader lightVolumeL0Shader = Shader.Find("Hidden/LV_DebugDisplayL0");
+        }
+
+        static readonly SceneView.CameraMode lightVolumeL0Mode;
+
+        static readonly HashSet<SceneView> setupSceneViews = new HashSet<SceneView>();
+
+        static SceneLightVolumeL0Mode()
+        {
+            lightVolumeL0Mode = SceneView.AddCameraMode("VRC Light Volumes L0", "Light Volumes Debug");
+
+            SceneView.beforeSceneGui += view =>
+            {
+                if (setupSceneViews.Add(view))
+                {
+                    view.onCameraModeChanged += cameraMode =>
+                    {
+                        if (cameraMode == lightVolumeL0Mode)
+                        {
+                            view.SetSceneViewShaderReplace(Cache.lightVolumeL0Shader, string.Empty);
+                        }
+                        else if (view.cameraMode.drawMode == DrawCameraMode.Textured)
+                        {
+                            view.SetSceneViewShaderReplace(null, string.Empty);
+                        }
+                    };
+                }
+            };
+        }
+    }
+    
+    [InitializeOnLoad]
+    sealed class SceneLightVolumeL1Mode
+    {
+        static class Cache
+        {
+            public static readonly Shader lightVolumeL1Shader = Shader.Find("Hidden/LV_DebugDisplayL1");
+        }
+
+        static readonly SceneView.CameraMode lightVolumeL1Mode;
+
+        static readonly HashSet<SceneView> setupSceneViews = new HashSet<SceneView>();
+
+        static SceneLightVolumeL1Mode()
+        {
+            lightVolumeL1Mode = SceneView.AddCameraMode("VRC Light Volumes L1", "Light Volumes Debug");
+
+            SceneView.beforeSceneGui += view =>
+            {
+                if (setupSceneViews.Add(view))
+                {
+                    view.onCameraModeChanged += cameraMode =>
+                    {
+                        if (cameraMode == lightVolumeL1Mode)
+                        {
+                            view.SetSceneViewShaderReplace(Cache.lightVolumeL1Shader, string.Empty);
+                        }
+                        else if (view.cameraMode.drawMode == DrawCameraMode.Textured)
+                        {
+                            view.SetSceneViewShaderReplace(null, string.Empty);
+                        }
+                    };
+                }
+            };
+        }
+    }
+}

--- a/Packages/red.sim.lightvolumes/Scripts/Editor/LightVolumePreview.cs.meta
+++ b/Packages/red.sim.lightvolumes/Scripts/Editor/LightVolumePreview.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6c99e7dfb62e6d046a704e559cd0e75c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/red.sim.lightvolumes/Shaders/Editor/LV_UnityPreview.shader
+++ b/Packages/red.sim.lightvolumes/Shaders/Editor/LV_UnityPreview.shader
@@ -1,0 +1,41 @@
+Shader "Hidden/LV_DebugDisplayL0"
+{
+    SubShader
+    {
+        Pass
+        {
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+
+            #include "UnityCG.cginc"
+            #include "Packages/red.sim.lightvolumes/Shaders/LightVolumes.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION; 
+            };
+
+            struct v2f
+            {
+                float4 worldPos : TEXCOORD0; 
+                float4 vertex   : SV_POSITION; 
+            };
+
+            v2f vert (appdata v)
+            {
+                v2f o;
+                o.worldPos = mul(unity_ObjectToWorld, v.vertex);
+
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                return o;
+            }
+
+            float4 frag (v2f i) : SV_Target
+            {
+                return float4(LightVolumeSH_L0(i.worldPos.xyz), 1.0);
+            }
+            ENDCG
+        }
+    }
+}

--- a/Packages/red.sim.lightvolumes/Shaders/Editor/LV_UnityPreview.shader.meta
+++ b/Packages/red.sim.lightvolumes/Shaders/Editor/LV_UnityPreview.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 793a273ca8d867445abb9568f89c656a
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/red.sim.lightvolumes/Shaders/Editor/LV_UnityPreviewL1.shader
+++ b/Packages/red.sim.lightvolumes/Shaders/Editor/LV_UnityPreviewL1.shader
@@ -1,0 +1,52 @@
+Shader "Hidden/LV_DebugDisplayL1"
+{
+    SubShader
+    {
+        Pass
+        {
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+
+            #include "UnityCG.cginc"
+            #include "Packages/red.sim.lightvolumes/Shaders/LightVolumes.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION; 
+                float3 normal : NORMAL;
+            };
+
+            struct v2f
+            {
+                float4 worldPos    : TEXCOORD0; 
+                float3 worldNormal : TEXCOORD1;
+                float4 vertex      : SV_POSITION; 
+            };
+
+            v2f vert (appdata v)
+            {
+                v2f o;
+                o.worldPos = mul(unity_ObjectToWorld, v.vertex);
+                o.worldNormal = UnityObjectToWorldNormal(v.normal);
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                return o;
+            }
+
+            float4 frag (v2f i) : SV_Target
+            {
+                float3 normalDir = normalize(i.worldNormal);
+
+                float3 L0 = 0; float3 L1r = 0; float3 L1g = 0; float3 L1b = 0;
+                LightVolumeSH(i.worldPos.xyz, L0, L1r, L1g, L1b);
+
+                float3 result;
+                result.r = dot(L1r, normalDir) + L0.r;
+                result.g = dot(L1g, normalDir) + L0.g;
+                result.b = dot(L1b, normalDir) + L0.b;
+                return float4(result, 1.0);
+            }
+            ENDCG
+        }
+    }
+}

--- a/Packages/red.sim.lightvolumes/Shaders/Editor/LV_UnityPreviewL1.shader.meta
+++ b/Packages/red.sim.lightvolumes/Shaders/Editor/LV_UnityPreviewL1.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 3d83b97e3afb31e4bb4e5095ed9d0cc1
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This adds a debug view to the scene draw mode selector for VRCLV debugging. Views for L0 and for L1 are implemented. I was inspired by [MomomaTools](https://github.com/momoma-null/MomomaTools), which has debug views for vertex colours. 
<img width="1350" height="1454" alt="Showing L0" src="https://github.com/user-attachments/assets/cc4e6c72-0f4a-4757-9be1-778742fc35ce" />
<img width="1350" height="1454" alt="Showing L1" src="https://github.com/user-attachments/assets/10d58b89-630c-48c6-9af1-1e9175a98b0b" />

There are some possible improvements...
- The base "Baked Lightmap" mode in Unity displays an Exposure bar the user can adjust. By default the L0/L1 view is pretty blown out, so this seems like a useful addition. I went to look at how Unity implemented this in their code, though, and it seemed kind of complicated, so I've left it for later. 
- Using the material's normal map for L1 preview could be nice, but it doesn't seem to match how the Unity previews work and would only look correct if the material uses BumpMap for normals. 