### PR TITLE
Attribution Rework

### DIFF
--- a/Packages/red.sim.lightvolumes/Attribution/LV_Logo_A.png
+++ b/Packages/red.sim.lightvolumes/Attribution/LV_Logo_A.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:be4be45d0c5752523b856de008ce8f220a5ca9a75ebc3bdb38b7638fc960d9f8
-size 49453
+oid sha256:e6f23a9b4cc815fd8be39842134c2a5da51d73665792ed6b69aaa81fac57f0ab
+size 59088

--- a/Packages/red.sim.lightvolumes/Attribution/LV_Logo_A.png.meta
+++ b/Packages/red.sim.lightvolumes/Attribution/LV_Logo_A.png.meta
@@ -10,7 +10,7 @@ TextureImporter:
     sRGBTexture: 1
     linearTexture: 0
     fadeOut: 0
-    borderMipMap: 0
+    borderMipMap: 1
     mipMapsPreserveCoverage: 0
     alphaTestReferenceValue: 0.5
     mipMapFadeDistanceStart: 1
@@ -72,7 +72,7 @@ TextureImporter:
     maxTextureSize: 2048
     resizeAlgorithm: 0
     textureFormat: -1
-    textureCompression: 1
+    textureCompression: 2
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0

--- a/Packages/red.sim.lightvolumes/Attribution/LV_Logo_B.png
+++ b/Packages/red.sim.lightvolumes/Attribution/LV_Logo_B.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:97a0bd89d643423aa066f02555ae7817de0a86587cb1642f2f080e8802e15cb7
-size 49749
+oid sha256:f1bf9d7eefedf0733238b0632960c03c1c664469a9dcd41102c632ecfabb47cf
+size 60293

--- a/Packages/red.sim.lightvolumes/Attribution/LV_Logo_B.png.meta
+++ b/Packages/red.sim.lightvolumes/Attribution/LV_Logo_B.png.meta
@@ -10,7 +10,7 @@ TextureImporter:
     sRGBTexture: 1
     linearTexture: 0
     fadeOut: 0
-    borderMipMap: 0
+    borderMipMap: 1
     mipMapsPreserveCoverage: 0
     alphaTestReferenceValue: 0.5
     mipMapFadeDistanceStart: 1
@@ -72,7 +72,7 @@ TextureImporter:
     maxTextureSize: 2048
     resizeAlgorithm: 0
     textureFormat: -1
-    textureCompression: 1
+    textureCompression: 2
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0

--- a/Packages/red.sim.lightvolumes/Attribution/Prefab VRC Light Volumes Attribution A.prefab
+++ b/Packages/red.sim.lightvolumes/Attribution/Prefab VRC Light Volumes Attribution A.prefab
@@ -28,7 +28,7 @@ Transform:
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0.7071068, z: -0, w: -0.7071068}
   m_LocalPosition: {x: -3.975, y: 2.148, z: -20.208}
-  m_LocalScale: {x: 2.167969, y: 0.75, z: 0.75}
+  m_LocalScale: {x: 2, y: 1, z: 1}
   m_ConstrainProportionsScale: 1
   m_Children: []
   m_Father: {fileID: 0}
@@ -61,7 +61,7 @@ MeshRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 2100000, guid: d102c05e48d614a489538849889bb3bd, type: 2}
+  - {fileID: 2100000, guid: d05590ed9a5a6d143a1fcee2fc90b71b, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0

--- a/Packages/red.sim.lightvolumes/Attribution/Prefab VRC Light Volumes Attribution B.prefab
+++ b/Packages/red.sim.lightvolumes/Attribution/Prefab VRC Light Volumes Attribution B.prefab
@@ -28,7 +28,7 @@ Transform:
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0.7071068, z: -0, w: -0.7071068}
   m_LocalPosition: {x: -3.975, y: 1.266, z: -20.208}
-  m_LocalScale: {x: 2.1679688, y: 0.75, z: 0.75}
+  m_LocalScale: {x: 2, y: 1, z: 1}
   m_ConstrainProportionsScale: 1
   m_Children: []
   m_Father: {fileID: 0}
@@ -61,7 +61,7 @@ MeshRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 2100000, guid: d05590ed9a5a6d143a1fcee2fc90b71b, type: 2}
+  - {fileID: 2100000, guid: d102c05e48d614a489538849889bb3bd, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0


### PR DESCRIPTION
Remade Texture as a power of 2 for better compression, enabled Replicate Border on Textures to don't have glitches on mipmaps, Set Compression to High cause of transparency (Still only 17% of Size of NPot), Swapped Materials on Prefabs, as Prefab A was using Material/Texture B and vice versa, rescaled Prefabs to match new texture aspect ratio