### PR TITLE
Fix attempt for Point Light Volume prefab instance edits not applying on build

### DIFF
--- a/Packages/red.sim.lightvolumes/Scripts/PointLightVolume.cs
+++ b/Packages/red.sim.lightvolumes/Scripts/PointLightVolume.cs
@@ -218,6 +218,10 @@ namespace VRCLightVolumes {
                 PointLightVolumeInstance.Color = Color;
                 PointLightVolumeInstance.Intensity = Intensity;
                 PointLightVolumeInstance.IsRangeDirty = true;
+#if UNITY_EDITOR
+                // Mark changes to ensure prefab modifications are recorded
+                LVUtils.MarkDirty(PointLightVolumeInstance);
+#endif
                 if (Type == LightType.PointLight) { // Point light
                     if (Shape == LightShape.Custom && Cubemap != null) {
                         PointLightVolumeInstance.SetLightSourceSize(LightSourceSize);


### PR DESCRIPTION
Added a call to mark the Point Light Volume prefab instances as dirty in unity editor to apply prefab edits