### PR TITLE
A fix and an optimization for Post Processor hooks

### DIFF
--- a/Packages/red.sim.lightvolumes/Scripts/Editor/LightVolumeSetupEditor.cs
+++ b/Packages/red.sim.lightvolumes/Scripts/Editor/LightVolumeSetupEditor.cs
@@ -249,10 +249,10 @@ namespace VRCLightVolumes {
                 var tex = _lightVolumeSetup.LightVolumeManager.LightVolumeAtlasBase;
                 vCount = (ulong)tex.width * (ulong)tex.height * (ulong)tex.depth;
 
-                if (_lightVolumeSetup.LightVolumeManager.AtlasPostProcessors != null) {
-                    foreach (var crt in _lightVolumeSetup.LightVolumeManager.AtlasPostProcessors) {
-                        if (crt != null) {
-                            vCount += (ulong)crt.width * (ulong)crt.height * (ulong)crt.volumeDepth;
+                if (_lightVolumeSetup.AtlasPostProcessors != null) {
+                    foreach (var pp in _lightVolumeSetup.AtlasPostProcessors) {
+                        if (pp.RT != null) {
+                            vCount += (ulong)pp.RT.width * (ulong)pp.RT.height * (ulong)pp.RT.volumeDepth;
                         }
                     }
                 }

--- a/Packages/red.sim.lightvolumes/Scripts/LightVolumeSetup.cs
+++ b/Packages/red.sim.lightvolumes/Scripts/LightVolumeSetup.cs
@@ -13,6 +13,7 @@ using System.IO;
 using UnityEditor.SceneManagement;
 using UnityEngine.SceneManagement;
 using UnityEngine.Diagnostics;
+using System.Linq;
 #endif
 
 namespace VRCLightVolumes {
@@ -65,6 +66,17 @@ namespace VRCLightVolumes {
         public bool DestroyInPlayMode = false;
 
         [SerializeField] public List<LightVolumeData> LightVolumeDataList = new List<LightVolumeData>();
+
+        [Serializable]
+        public struct PostProcessor {
+            public RenderTexture RT;
+            public Material Mat;
+            public string TextureName;
+            public Action Update;
+        }
+
+        [Tooltip("Render Textures that will be applied top to bottom to the Light Volume Atlas at runtime. External scripts can register themselves here using `RegisterPostProcessorCRT`. You probably don't want to mess with this field manually.")]
+        public PostProcessor[] AtlasPostProcessors;
 
         public bool IsBakeryMode => BakingMode == Baking.Bakery; // Just a shortcut
         public LightVolumeManager LightVolumeManager;
@@ -423,7 +435,7 @@ namespace VRCLightVolumes {
             // @pimaker: If there are post processors, the 3D texture will run through a Custom Render Texture every frame.
             // Unity dispatches CRT renders on 3D textures in slices by depth, so we want to reduce the z axis of the atlas
             // as much as possible to reduce per-frame drawcalls - even at the cost of slightly higher VRAM efficiency.
-            var packingStrategy = LightVolumeManager.AtlasPostProcessors != null && LightVolumeManager.AtlasPostProcessors.Length > 0
+            var packingStrategy = AtlasPostProcessors != null && AtlasPostProcessors.Length > 0 && AtlasPostProcessors.Any(pp => pp.RT is CustomRenderTexture)
                 ? TexturePackingStrategy.MinimumDepth : TexturePackingStrategy.MinimumVRAM;
 
             _generateAtlasCoroutine = EditorCoroutineUtility.StartCoroutine(Texture3DAtlasGenerator.CreateAtlas(LightVolumes.ToArray(), (Atlas3D atlas) => {
@@ -641,33 +653,46 @@ namespace VRCLightVolumes {
             return list.ToArray();
         }
 
+#if UNITY_EDITOR
         public void RegisterPostProcessorCRT(CustomRenderTexture crt) {
             if (crt == null) return;
-            LightVolumeManager.AtlasPostProcessors ??= new CustomRenderTexture[0];
-            if (Array.IndexOf(LightVolumeManager.AtlasPostProcessors, crt) != -1) return;
-            Array.Resize(ref LightVolumeManager.AtlasPostProcessors, LightVolumeManager.AtlasPostProcessors.Length + 1);
-            LightVolumeManager.AtlasPostProcessors[^1] = crt;
+            AtlasPostProcessors ??= new PostProcessor[0];
+            if (AtlasPostProcessors.Any(pp => pp.RT == crt)) return;
+            Array.Resize(ref AtlasPostProcessors, AtlasPostProcessors.Length + 1);
+            AtlasPostProcessors[^1] = new PostProcessor { RT = crt, Mat = crt.material, TextureName = "_MainTex", Update = crt.Update };
             Debug.Log($"[LightVolumeSetup] Registered post processor CRT: {crt.name}");
             UpdatePostProcessors();
         }
 
-        public void UnregisterPostProcessorCRT(CustomRenderTexture crt) {
-            if (crt == null || LightVolumeManager.AtlasPostProcessors == null) return;
-            var index = Array.IndexOf(LightVolumeManager.AtlasPostProcessors, crt);
+        public void UnregisterPostProcessorCRT(CustomRenderTexture crt) => UnregisterPostProcessor(crt); // API backwards compat
+        public void UnregisterPostProcessor(RenderTexture crt) {
+            if (crt == null || AtlasPostProcessors == null) return;
+            var index = Array.FindIndex(AtlasPostProcessors, pp => pp.RT == crt);
             if (index < 0) return;
-            var newArray = new CustomRenderTexture[LightVolumeManager.AtlasPostProcessors.Length - 1];
-            for (int i = 0, j = 0; i < LightVolumeManager.AtlasPostProcessors.Length; i++) {
+            var newArray = new PostProcessor[AtlasPostProcessors.Length - 1];
+            for (int i = 0, j = 0; i < AtlasPostProcessors.Length; i++) {
                 if (i != index) {
-                    newArray[j++] = LightVolumeManager.AtlasPostProcessors[i];
+                    newArray[j] = AtlasPostProcessors[i];
+                    j++;
                 }
             }
-            LightVolumeManager.AtlasPostProcessors = newArray;
+            AtlasPostProcessors = newArray;
             Debug.Log($"[LightVolumeSetup] Unregistered post processor CRT: {crt.name}");
             UpdatePostProcessors();
         }
 
+        public void RegisterPostProcessor(PostProcessor pp) {
+            if (pp.RT == null || pp.Mat == null) return;
+            AtlasPostProcessors ??= new PostProcessor[0];
+            if (AtlasPostProcessors.Any(existing => existing.RT == pp.RT)) return;
+            Array.Resize(ref AtlasPostProcessors, AtlasPostProcessors.Length + 1);
+            AtlasPostProcessors[^1] = pp;
+            Debug.Log($"[LightVolumeSetup] Registered post processor: {pp.RT.name}");
+            UpdatePostProcessors();
+        }
+
         private void UpdatePostProcessors() {
-            if (LightVolumeManager.AtlasPostProcessors == null || LightVolumeManager.AtlasPostProcessors.Length == 0) {
+            if (AtlasPostProcessors == null || AtlasPostProcessors.Length == 0) {
                 // no post processors, just use base atlas
                 LightVolumeManager.LightVolumeAtlas = LightVolumeManager.LightVolumeAtlasBase;
                 return;
@@ -675,30 +700,36 @@ namespace VRCLightVolumes {
 
             Texture3D baseAtlas = LightVolumeManager.LightVolumeAtlasBase;
             Texture prevAtlas = baseAtlas;
-            foreach (var crt in LightVolumeManager.AtlasPostProcessors) {
-                if (crt == null) continue;
+            foreach (PostProcessor pp in AtlasPostProcessors) {
+                RenderTexture rt = pp.RT;
+                Material mat = pp.Mat;
+                if (rt == null || mat == null) continue;
 
                 // enforce some base settings to ensure no quality loss between post processors
-                crt.Release();
-                crt.dimension = UnityEngine.Rendering.TextureDimension.Tex3D;
-                crt.graphicsFormat = UnityEngine.Experimental.Rendering.GraphicsFormat.R16G16B16A16_SFloat;
-                crt.updateMode = CustomRenderTextureUpdateMode.Realtime;
+                rt.Release();
+                rt.dimension = UnityEngine.Rendering.TextureDimension.Tex3D;
+                rt.graphicsFormat = UnityEngine.Experimental.Rendering.GraphicsFormat.R16G16B16A16_SFloat;
+                if (rt is CustomRenderTexture crt)
+                    crt.updateMode = CustomRenderTextureUpdateMode.Realtime;
+
                 if (baseAtlas != null) {
-                    crt.width = baseAtlas.width;
-                    crt.height = baseAtlas.height;
-                    crt.volumeDepth = baseAtlas.depth;
+                    rt.width = baseAtlas.width;
+                    rt.height = baseAtlas.height;
+                    rt.volumeDepth = baseAtlas.depth;
                 }
 
                 // build processing chain
-                crt.material.mainTexture = prevAtlas;
-                prevAtlas = crt;
+                mat.SetTexture(pp.TextureName, prevAtlas);
+                prevAtlas = rt;
 
                 // store last CRT as active
-                LightVolumeManager.LightVolumeAtlas = crt;
+                LightVolumeManager.LightVolumeAtlas = rt;
 
-                crt.Update();
+                // force an update right away
+                pp.Update?.Invoke();
             }
         }
+#endif
 
         public void BakeOcclusionVolumes() {
 #if UNITY_EDITOR

--- a/Packages/red.sim.lightvolumes/Scripts/LightVolumeSetup.cs
+++ b/Packages/red.sim.lightvolumes/Scripts/LightVolumeSetup.cs
@@ -420,6 +420,12 @@ namespace VRCLightVolumes {
                 _generateAtlasCoroutine = null;
             }
 
+            // @pimaker: If there are post processors, the 3D texture will run through a Custom Render Texture every frame.
+            // Unity dispatches CRT renders on 3D textures in slices by depth, so we want to reduce the z axis of the atlas
+            // as much as possible to reduce per-frame drawcalls - even at the cost of slightly higher VRAM efficiency.
+            var packingStrategy = LightVolumeManager.AtlasPostProcessors != null && LightVolumeManager.AtlasPostProcessors.Length > 0
+                ? TexturePackingStrategy.MinimumDepth : TexturePackingStrategy.MinimumVRAM;
+
             _generateAtlasCoroutine = EditorCoroutineUtility.StartCoroutine(Texture3DAtlasGenerator.CreateAtlas(LightVolumes.ToArray(), (Atlas3D atlas) => {
 
                 if (atlas.Texture == null || DontSync) return; // Return if atlas packing failed
@@ -481,7 +487,7 @@ namespace VRCLightVolumes {
 
                 _generateAtlasCoroutine = null;
 
-            }, (int)DownscaleVolumes), this);
+            }, (int)DownscaleVolumes, packingStrategy), this);
 
         }
 

--- a/Packages/red.sim.lightvolumes/Scripts/LightVolumeSetup.cs
+++ b/Packages/red.sim.lightvolumes/Scripts/LightVolumeSetup.cs
@@ -636,8 +636,9 @@ namespace VRCLightVolumes {
         }
 
         public void RegisterPostProcessorCRT(CustomRenderTexture crt) {
-            if (crt == null || Array.IndexOf(LightVolumeManager.AtlasPostProcessors, crt) != -1) return;
+            if (crt == null) return;
             LightVolumeManager.AtlasPostProcessors ??= new CustomRenderTexture[0];
+            if (Array.IndexOf(LightVolumeManager.AtlasPostProcessors, crt) != -1) return;
             Array.Resize(ref LightVolumeManager.AtlasPostProcessors, LightVolumeManager.AtlasPostProcessors.Length + 1);
             LightVolumeManager.AtlasPostProcessors[^1] = crt;
             Debug.Log($"[LightVolumeSetup] Registered post processor CRT: {crt.name}");
@@ -645,7 +646,7 @@ namespace VRCLightVolumes {
         }
 
         public void UnregisterPostProcessorCRT(CustomRenderTexture crt) {
-            if (crt == null) return;
+            if (crt == null || LightVolumeManager.AtlasPostProcessors == null) return;
             var index = Array.IndexOf(LightVolumeManager.AtlasPostProcessors, crt);
             if (index < 0) return;
             var newArray = new CustomRenderTexture[LightVolumeManager.AtlasPostProcessors.Length - 1];

--- a/Packages/red.sim.lightvolumes/Scripts/Texture3DAtlasGenerator.cs
+++ b/Packages/red.sim.lightvolumes/Scripts/Texture3DAtlasGenerator.cs
@@ -12,13 +12,18 @@ namespace VRCLightVolumes {
         public Vector3[] BoundsUvwMax;
     }
 
+    public enum TexturePackingStrategy {
+        MinimumVRAM,
+        MinimumDepth,
+    }
+
     public static class Texture3DAtlasGenerator {
 
         const int maxAtlasSize = 2048;
 
         public static event Action<LightVolume[]> OnPreAtlasCreate;
 
-        public static IEnumerator CreateAtlas(LightVolume[] volumes, Action<Atlas3D> onComplete, int downscaleCount = 0) {
+        public static IEnumerator CreateAtlas(LightVolume[] volumes, Action<Atlas3D> onComplete, int downscaleCount = 0, TexturePackingStrategy packingStrategy = TexturePackingStrategy.MinimumVRAM) {
 
             Texture3D[] texs = null;
             const int padding = 1;
@@ -155,6 +160,7 @@ namespace VRCLightVolumes {
 
                     Vector3Int bestPos = Vector3Int.zero;
                     int bestVol = int.MaxValue;
+                    int bestD = int.MaxValue;
 
                     List<int> xCand = new List<int> { 0 };
                     List<int> yCand = new List<int> { 0 };
@@ -185,7 +191,14 @@ namespace VRCLightVolumes {
 
                                 int vol = newW * newH * newD;
 
-                                if (vol < bestVol) { bestVol = vol; bestPos = new Vector3Int(x, y, z); }
+                                switch (packingStrategy) {
+                                    case TexturePackingStrategy.MinimumVRAM:
+                                        if (vol < bestVol) { bestVol = vol; bestPos = new Vector3Int(x, y, z); }
+                                        break;
+                                    case TexturePackingStrategy.MinimumDepth:
+                                        if (newD < bestD || (newD == bestD && vol < bestVol)) { bestVol = vol; bestD = newD; bestPos = new Vector3Int(x, y, z); }
+                                        break;
+                                }
                             }
                         }
                         yield return null;

--- a/Packages/red.sim.lightvolumes/UScripts/LightVolumeManager.cs
+++ b/Packages/red.sim.lightvolumes/UScripts/LightVolumeManager.cs
@@ -22,8 +22,6 @@ namespace VRCLightVolumes {
         public Texture LightVolumeAtlas;
         [Tooltip("Combined Texture3D containing all baked Light Volume data. This field is not used at runtime, see LightVolumeAtlas instead. It specifies the base for the post process chain, if given.")]
         public Texture3D LightVolumeAtlasBase;
-        [Tooltip("Custom Render Textures that will be applied top to bottom to the Light Volume Atlas at runtime. External scripts can register themselves here using `RegisterPostProcessorCRT`. You probably don't want to mess with this field manually.")]
-        public CustomRenderTexture[] AtlasPostProcessors;
         [Tooltip("When enabled, areas outside Light Volumes fall back to light probes. Otherwise, the Light Volume with the smallest weight is used as fallback. It also improves performance.")]
         public bool LightProbesBlending = true;
         [Tooltip("Disables smooth blending with areas outside Light Volumes. Use it if your entire scene's play area is covered by Light Volumes. It also improves performance.")]


### PR DESCRIPTION
Been working more on my LTCGI integration, found a bug in my previous Post Processor contribution: https://github.com/REDSIM/VRCLightVolumes/pull/51

Also profiled a bit and found that Unity submits a new drawcall CPU->GPU for every depth layer in a 3D CRT 😬 To reduce perf impact, change the packing strategy to minimize depth at the cost of VRAM in that case. This improves performance in that specific case.

Additionally, allow regular RenderTextures to be post processors. The caller is responsible for updating those.