### PR TITLE
PR: #104 Feature Add optional minimum-lightness clamp to LightVolumeTVGI

### DIFF
--- a/Packages/red.sim.lightvolumes/Extra/TV Global Illumination/LightVolumeTVGI.asset
+++ b/Packages/red.sim.lightvolumes/Extra/TV Global Illumination/LightVolumeTVGI.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c333ccfdd0cbdbc4ca30cef2dd6e6b9b, type: 3}
   m_Name: LightVolumeTVGI
   m_EditorClassIdentifier: 
-  serializedUdonProgramAsset: {fileID: 11400000, guid: ac1fdbb47b5c6df4c86bb1867b3cd830, type: 2}
+  serializedUdonProgramAsset: {fileID: 11400000, guid: 6f2b549da9101274b84e661202e99303, type: 2}
   udonAssembly: 
   assemblyError: 
   sourceCsScript: {fileID: 11500000, guid: a050acdc976b3f8438922b3f664e5233, type: 3}
@@ -43,7 +43,7 @@ MonoBehaviour:
       Data: 
     - Name: 
       Entry: 12
-      Data: 9
+      Data: 11
     - Name: 
       Entry: 7
       Data: 
@@ -178,16 +178,139 @@ MonoBehaviour:
       Data: 
     - Name: $k
       Entry: 1
-      Data: TargetLightVolumes
+      Data: ClampSampleLightness
     - Name: $v
       Entry: 7
       Data: 10|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
+      Data: ClampSampleLightness
+    - Name: <UserType>k__BackingField
+      Entry: 9
+      Data: 7
+    - Name: <SystemType>k__BackingField
+      Entry: 9
+      Data: 7
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: true
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 11|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 1
+    - Name: 
+      Entry: 7
+      Data: 12|UnityEngine.TooltipAttribute, UnityEngine.CoreModule
+    - Name: tooltip
+      Entry: 1
+      Data: Clamp the sampled color's lightness to a minimum so dark scenes don't
+        fade the light to black. Off by default.
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: SampleLightnessRange
+    - Name: $v
+      Entry: 7
+      Data: 13|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: SampleLightnessRange
+    - Name: <UserType>k__BackingField
+      Entry: 7
+      Data: 14|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: UnityEngine.Vector2, UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <SystemType>k__BackingField
+      Entry: 9
+      Data: 14
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: true
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 15|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 1
+    - Name: 
+      Entry: 7
+      Data: 16|UnityEngine.TooltipAttribute, UnityEngine.CoreModule
+    - Name: tooltip
+      Entry: 1
+      Data: Lightness clamp range. Left value is the near-black cutoff. Right value
+        is the minimum lightness. Frames whose lightness falls inside this range
+        are boosted to the right-side value.
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: TargetLightVolumes
+    - Name: $v
+      Entry: 7
+      Data: 17|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
       Data: TargetLightVolumes
     - Name: <UserType>k__BackingField
       Entry: 7
-      Data: 11|System.RuntimeType, mscorlib
+      Data: 18|System.RuntimeType, mscorlib
     - Name: 
       Entry: 1
       Data: VRCLightVolumes.LightVolumeInstance[], red.sim.LightVolumesUdon
@@ -196,7 +319,7 @@ MonoBehaviour:
       Data: 
     - Name: <SystemType>k__BackingField
       Entry: 7
-      Data: 12|System.RuntimeType, mscorlib
+      Data: 19|System.RuntimeType, mscorlib
     - Name: 
       Entry: 1
       Data: UnityEngine.Component[], UnityEngine.CoreModule
@@ -217,13 +340,13 @@ MonoBehaviour:
       Data: true
     - Name: _fieldAttributes
       Entry: 7
-      Data: 13|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+      Data: 20|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
       Data: 2
     - Name: 
       Entry: 7
-      Data: 14|UnityEngine.SpaceAttribute, UnityEngine.CoreModule
+      Data: 21|UnityEngine.SpaceAttribute, UnityEngine.CoreModule
     - Name: height
       Entry: 4
       Data: 8
@@ -232,7 +355,7 @@ MonoBehaviour:
       Data: 
     - Name: 
       Entry: 7
-      Data: 15|UnityEngine.TooltipAttribute, UnityEngine.CoreModule
+      Data: 22|UnityEngine.TooltipAttribute, UnityEngine.CoreModule
     - Name: tooltip
       Entry: 1
       Data: List of the Light Volumes that should be affected by the Light Volume
@@ -260,13 +383,13 @@ MonoBehaviour:
       Data: TargetPointLightVolumes
     - Name: $v
       Entry: 7
-      Data: 16|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+      Data: 23|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
       Data: TargetPointLightVolumes
     - Name: <UserType>k__BackingField
       Entry: 7
-      Data: 17|System.RuntimeType, mscorlib
+      Data: 24|System.RuntimeType, mscorlib
     - Name: 
       Entry: 1
       Data: VRCLightVolumes.PointLightVolumeInstance[], red.sim.LightVolumesUdon
@@ -275,7 +398,7 @@ MonoBehaviour:
       Data: 
     - Name: <SystemType>k__BackingField
       Entry: 9
-      Data: 12
+      Data: 19
     - Name: <SyncMode>k__BackingField
       Entry: 7
       Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
@@ -290,13 +413,13 @@ MonoBehaviour:
       Data: true
     - Name: _fieldAttributes
       Entry: 7
-      Data: 18|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+      Data: 25|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
       Data: 1
     - Name: 
       Entry: 7
-      Data: 19|UnityEngine.TooltipAttribute, UnityEngine.CoreModule
+      Data: 26|UnityEngine.TooltipAttribute, UnityEngine.CoreModule
     - Name: tooltip
       Entry: 1
       Data: List of the Point Light Volumes that should be affected by the Light
@@ -324,13 +447,13 @@ MonoBehaviour:
       Data: _pixels
     - Name: $v
       Entry: 7
-      Data: 20|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+      Data: 27|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
       Data: _pixels
     - Name: <UserType>k__BackingField
       Entry: 7
-      Data: 21|System.RuntimeType, mscorlib
+      Data: 28|System.RuntimeType, mscorlib
     - Name: 
       Entry: 1
       Data: UnityEngine.Color32[], UnityEngine.CoreModule
@@ -339,7 +462,7 @@ MonoBehaviour:
       Data: 
     - Name: <SystemType>k__BackingField
       Entry: 9
-      Data: 21
+      Data: 28
     - Name: <SyncMode>k__BackingField
       Entry: 7
       Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
@@ -354,7 +477,7 @@ MonoBehaviour:
       Data: false
     - Name: _fieldAttributes
       Entry: 7
-      Data: 22|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+      Data: 29|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
       Data: 0
@@ -378,13 +501,13 @@ MonoBehaviour:
       Data: _prevColor
     - Name: $v
       Entry: 7
-      Data: 23|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+      Data: 30|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
       Data: _prevColor
     - Name: <UserType>k__BackingField
       Entry: 7
-      Data: 24|System.RuntimeType, mscorlib
+      Data: 31|System.RuntimeType, mscorlib
     - Name: 
       Entry: 1
       Data: UnityEngine.Color, UnityEngine.CoreModule
@@ -393,7 +516,7 @@ MonoBehaviour:
       Data: 
     - Name: <SystemType>k__BackingField
       Entry: 9
-      Data: 24
+      Data: 31
     - Name: <SyncMode>k__BackingField
       Entry: 7
       Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
@@ -408,7 +531,7 @@ MonoBehaviour:
       Data: false
     - Name: _fieldAttributes
       Entry: 7
-      Data: 25|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+      Data: 32|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
       Data: 0
@@ -432,13 +555,13 @@ MonoBehaviour:
       Data: _timePrev
     - Name: $v
       Entry: 7
-      Data: 26|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+      Data: 33|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
       Data: _timePrev
     - Name: <UserType>k__BackingField
       Entry: 7
-      Data: 27|System.RuntimeType, mscorlib
+      Data: 34|System.RuntimeType, mscorlib
     - Name: 
       Entry: 1
       Data: System.Single, mscorlib
@@ -447,7 +570,7 @@ MonoBehaviour:
       Data: 
     - Name: <SystemType>k__BackingField
       Entry: 9
-      Data: 27
+      Data: 34
     - Name: <SyncMode>k__BackingField
       Entry: 7
       Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
@@ -462,7 +585,7 @@ MonoBehaviour:
       Data: false
     - Name: _fieldAttributes
       Entry: 7
-      Data: 28|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+      Data: 35|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
       Data: 0
@@ -486,13 +609,13 @@ MonoBehaviour:
       Data: _downsampledTex
     - Name: $v
       Entry: 7
-      Data: 29|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+      Data: 36|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
       Data: _downsampledTex
     - Name: <UserType>k__BackingField
       Entry: 7
-      Data: 30|System.RuntimeType, mscorlib
+      Data: 37|System.RuntimeType, mscorlib
     - Name: 
       Entry: 1
       Data: UnityEngine.RenderTexture, UnityEngine.CoreModule
@@ -501,7 +624,7 @@ MonoBehaviour:
       Data: 
     - Name: <SystemType>k__BackingField
       Entry: 9
-      Data: 30
+      Data: 37
     - Name: <SyncMode>k__BackingField
       Entry: 7
       Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
@@ -516,7 +639,7 @@ MonoBehaviour:
       Data: false
     - Name: _fieldAttributes
       Entry: 7
-      Data: 31|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+      Data: 38|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
       Data: 0
@@ -540,7 +663,7 @@ MonoBehaviour:
       Data: _readbackPending
     - Name: $v
       Entry: 7
-      Data: 32|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+      Data: 39|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
       Data: _readbackPending
@@ -564,7 +687,7 @@ MonoBehaviour:
       Data: false
     - Name: _fieldAttributes
       Entry: 7
-      Data: 33|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+      Data: 40|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
       Data: 0

--- a/Packages/red.sim.lightvolumes/Extra/TV Global Illumination/LightVolumeTVGI.cs
+++ b/Packages/red.sim.lightvolumes/Extra/TV Global Illumination/LightVolumeTVGI.cs
@@ -23,6 +23,11 @@ namespace VRCLightVolumes {
         public Texture TargetRenderTexture;
         [Tooltip("Enables a smoothing algorithm that tries to smooth out flickering that is usually a problem. Recommended to always be turned on.")]
         public bool AntiFlickering = true;
+        [Tooltip("Clamp the sampled color's lightness to a minimum so dark scenes don't fade the light to black. Off by default.")]
+        public bool ClampSampleLightness;
+        [Tooltip("Lightness clamp range. Left value is the near-black cutoff. Right value is the minimum lightness. Frames whose lightness falls inside this range are boosted to the right-side value.")]
+        [MinMaxSlider(0f, 1f)]
+        public Vector2 SampleLightnessRange = new Vector2(0.003f, 0.3f);
         [Space]
         [Tooltip("List of the Light Volumes that should be affected by the Light Volume TVGI script.")]
         public LightVolumeInstance[] TargetLightVolumes;
@@ -119,6 +124,16 @@ namespace VRCLightVolumes {
             // Custom delta time for the async stuff 
             float dTime = Time.time - _timePrev;
             _timePrev = Time.time;
+
+            // Raise the sampled color to the range's top when it's dim but not near-black.
+            // Bright and near-black frames are left alone.
+            if (ClampSampleLightness) {
+                float h, s, v;
+                Color.RGBToHSV(color, out h, out s, out v);
+                if (v > SampleLightnessRange.x && v < SampleLightnessRange.y) {
+                    color = Color.HSVToRGB(h, s, SampleLightnessRange.y);
+                }
+            }
 
             if (AntiFlickering) {
                 float rmean = (color.r + _prevColor.r) * 0.5f;

--- a/Packages/red.sim.lightvolumes/Extra/TV Global Illumination/MinMaxSliderAttribute.cs
+++ b/Packages/red.sim.lightvolumes/Extra/TV Global Illumination/MinMaxSliderAttribute.cs
@@ -1,0 +1,14 @@
+using UnityEngine;
+
+namespace VRCLightVolumes {
+    // Draws a Vector2 as a two-handle min/max slider. x = low handle, y = high handle.
+    public class MinMaxSliderAttribute : PropertyAttribute {
+        public readonly float Min;
+        public readonly float Max;
+
+        public MinMaxSliderAttribute(float min, float max) {
+            Min = min;
+            Max = max;
+        }
+    }
+}

--- a/Packages/red.sim.lightvolumes/Extra/TV Global Illumination/MinMaxSliderAttribute.cs.meta
+++ b/Packages/red.sim.lightvolumes/Extra/TV Global Illumination/MinMaxSliderAttribute.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2fcc37d288ee8334597b0adc8eea493d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/red.sim.lightvolumes/Scripts/Editor/MinMaxSliderDrawer.cs
+++ b/Packages/red.sim.lightvolumes/Scripts/Editor/MinMaxSliderDrawer.cs
@@ -1,0 +1,45 @@
+using UnityEngine;
+using UnityEditor;
+
+namespace VRCLightVolumes {
+    // Renders a [MinMaxSlider] Vector2 as: label | min field | two-handle slider | max field.
+    [CustomPropertyDrawer(typeof(MinMaxSliderAttribute))]
+    public class MinMaxSliderDrawer : PropertyDrawer {
+        const float FieldWidth = 50f;
+        const float Pad = 4f;
+
+        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label) {
+            if (property.propertyType != SerializedPropertyType.Vector2) {
+                EditorGUI.PropertyField(position, property, label);
+                return;
+            }
+
+            MinMaxSliderAttribute attr = (MinMaxSliderAttribute)attribute;
+
+            EditorGUI.BeginProperty(position, label, property);
+            Rect r = EditorGUI.PrefixLabel(position, label);
+
+            Vector2 value = property.vector2Value;
+            float min = value.x;
+            float max = value.y;
+
+            Rect minRect = new Rect(r.x, r.y, FieldWidth, r.height);
+            Rect sliderRect = new Rect(r.x + FieldWidth + Pad, r.y, r.width - 2f * (FieldWidth + Pad), r.height);
+            Rect maxRect = new Rect(r.xMax - FieldWidth, r.y, FieldWidth, r.height);
+
+            EditorGUI.BeginChangeCheck();
+            min = EditorGUI.FloatField(minRect, min);
+            EditorGUI.MinMaxSlider(sliderRect, ref min, ref max, attr.Min, attr.Max);
+            max = EditorGUI.FloatField(maxRect, max);
+
+            if (EditorGUI.EndChangeCheck()) {
+                min = Mathf.Clamp(min, attr.Min, attr.Max);
+                max = Mathf.Clamp(max, attr.Min, attr.Max);
+                if (min > max) min = max;
+                property.vector2Value = new Vector2(min, max);
+            }
+
+            EditorGUI.EndProperty();
+        }
+    }
+}

--- a/Packages/red.sim.lightvolumes/Scripts/Editor/MinMaxSliderDrawer.cs.meta
+++ b/Packages/red.sim.lightvolumes/Scripts/Editor/MinMaxSliderDrawer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a8441b5551cc26940b24be98b561a6d1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Additions

An opt-in minimum-lightness clamp for the TV Global Illumination script, for content that averages dark (a mostly-black scene with a few bright points) but should still cast a baseline amount of light.

- `ClampSampleLightness` (bool, off by default): the toggle.
- `SampleLightnessRange` (Vector2, shown as a two-handle min/max slider): the left handle is a near-black cutoff, the right handle is the minimum lightness. Any frame whose averaged HSV lightness lands between the handles is raised to the right handle. Frames below the cutoff stay dark (true blacks stay black) and frames already above the minimum pass through untouched.

## Behavior

- With the toggle off, the sampled color is unchanged, so existing setups behave exactly as before.
- `HSVToRGB` only runs on frames actually inside the range, so bright and near-black frames skip the conversion.
- The clamp runs before the anti-flicker smoothing, so smoothing eases toward the clamped color and no extra flicker is introduced.

Closes Issue #104

Contributor: flipbits